### PR TITLE
fix(release): fix undefined changelog path variable

### DIFF
--- a/utils/scripts/release.js
+++ b/utils/scripts/release.js
@@ -18,6 +18,7 @@ const spinner = ora();
 
 const ALLOWED_RELEASE_BRANCHES = ['release/*'];
 const INSERTION_SLUG = '<!-- insert-new-changelog-here -->';
+const changelogPath = resolve(__dirname, '..', '..', 'CHANGELOG.md');
 
 const printCommits = async () => {
   spinner.start('Commits since current version:');
@@ -52,7 +53,6 @@ const generateChangelog = async () => {
   await write(fd, markdown);
 
   const readFile = util.promisify(fs.readFile);
-  const changelogPath = resolve(__dirname, '..', '..', 'CHANGELOG.md');
   const data = await readFile(changelogPath, 'utf8');
 
   if (data.includes(INSERTION_SLUG)) {


### PR DESCRIPTION
## 📝 Description

> The release script had an undefined changelog path variable inside a function because it was defined in another function. So I moved its declaration to the global scope.

## ⛳️ Current behavior (updates)

> The release script exits with an error.

## 🚀 New behavior

> The release script finishes successfully.

## 📝 Additional Information

## ✅ Pull Request Checklist:

- [ ] :ok_hand: Design updates are approved by design team
- [ ] :white_check_mark: Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] :wheelchair: Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)
