### PR TITLE
fix(publish): allow publishing from the master branch

### DIFF
--- a/utils/scripts/publish.js
+++ b/utils/scripts/publish.js
@@ -11,7 +11,7 @@ const { assertGitBranch, displayError } = require('./common');
 
 const spinner = ora();
 
-const ALLOWED_PUBLISH_BRANCHES = ['main'];
+const ALLOWED_PUBLISH_BRANCHES = ['master'];
 
 const publishToNpm = async () => {
   spinner.start('Publishing to NPM');


### PR DESCRIPTION
## 📝 Description

> The publish script had a bug specifying that it could only be run from the `main` branch. But this is an error since we don't have a `main` branch, we instead have the `master` branch.

## ⛳️ Current behavior (updates)

> The publish script throws an error since it can only run on the `main` branch

## 🚀 New behavior

> The publish script can be run from the `master branch`

## 📝 Additional Information

## ✅ Pull Request Checklist:

- [ ] :ok_hand: Design updates are approved by design team
- [ ] :white_check_mark: Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] :wheelchair: Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)
